### PR TITLE
Feature/install

### DIFF
--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -1,9 +1,10 @@
 # click is our CLI library
 import click
+import os
 
 # local imports
 from .cmd_dev import run_dev_server
-from .utils import get_target_dir, get_app_path, get_site_packages, download_boilerplate
+from .utils import get_target_dir, get_app_path, get_site_packages, download_boilerplate, create_venv, install_venv
 
 @click.group()
 def cli():
@@ -11,13 +12,30 @@ def cli():
 
 @click.command()
 @click.argument('path', type=click.Path(exists=False, dir_okay=True, file_okay=False), nargs=-1)
-def init(path):
+@click.option('--no-venv', default=False, required=False, type=bool, help="Disable automatic use of a virtual environment")
+def init(path, no_venv):
     click.echo('⏰ Downloading boilerplate...')
     target_dir = get_target_dir(path)
     download_boilerplate(target_dir)
+    if not no_venv:
+        click.echo('🌎 Creating virtual environment...')
+        venv_path = os.path.join(target_dir, "venv")
+        create_venv(venv_path)
+        click.echo('📦 Downloading packages...')
+        req_path = os.path.join(target_dir, "requirements.txt")
+        install_venv(req_path, venv_path)
     click.echo('\n🍌 Project ready to go (hurrah!)')
     click.echo('\n🔥 To run a dev server with hot-reload, run:')
     click.echo('banana dev')
+
+@click.command()
+@click.option('--venv', default="venv", required=False, type=str, help="The path of the virtual environment to install into. Defaults to venv.")
+def install(venv):
+    if not os.path.exists(venv):
+        click.echo('🌎 Creating virtual environment...')
+        create_venv(venv)
+    click.echo('📦 Downloading packages...')
+    install_venv("requirements.txt", venv)
 
 @click.command()
 @click.option('--venv', default="venv", required=False, type=str, help="The path of the virtual environment to run in. Defaults to venv.")
@@ -28,6 +46,7 @@ def dev(venv, entrypoint):
     run_dev_server(app_path, site_packages)
 
 cli.add_command(init)
+cli.add_command(install)
 cli.add_command(dev)
 
 if __name__ == "__main__":

--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -12,7 +12,7 @@ def cli():
 
 @click.command()
 @click.argument('path', type=click.Path(exists=False, dir_okay=True, file_okay=False), nargs=-1)
-@click.option('--no-venv', default=False, required=False, type=bool, help="Disable automatic use of a virtual environment")
+@click.option('--no-venv', is_flag=True, required=False, help="Disable automatic use of a virtual environment")
 def init(path, no_venv):
     click.echo('⏰ Downloading boilerplate...')
     target_dir = get_target_dir(path)

--- a/banana_cli/cmd_dev.py
+++ b/banana_cli/cmd_dev.py
@@ -55,7 +55,7 @@ def run_dev_server(app_path, site_packages):
         b1, b2 = split_file(app_path)
         if b1 != prev_b1:
             if first_run:
-                print(colored("\n------\nStarting server 🍌\n------", 'green'))
+                print(colored("------\nStarting server 🍌\n------", 'green'))
                 first_run = False
             else:
                 print(colored("\n------\nInit block changed\nRestarting init + handler\n------", 'green'))

--- a/banana_cli/utils.py
+++ b/banana_cli/utils.py
@@ -1,6 +1,8 @@
 import os
+import venv
 import shutil
-import click
+import subprocess
+import sys
 
 # Uses git to clone the potassium boilerplate from /boilerplate/potassium in this git repo
 def download_boilerplate(target_dir):
@@ -72,3 +74,12 @@ def get_site_packages(app_path, venv_name = "venv"):
         return None 
     
     return site_packages_dir
+
+# create a venv
+def create_venv(venv_path):
+    venv.create(venv_path, with_pip=True)
+
+# install requirements.txt into venv
+def install_venv(req_path, venv_path):
+    python_interpreter = os.path.join(venv_path, "bin", "python3")
+    subprocess.check_call([python_interpreter, "-m", "pip", "install", "-r", req_path])


### PR DESCRIPTION
# What is this?
Adds a `banana install` function to CLI, which:
- makes a venv
- uses the venv pip to install requirements.txt

Also makes `banana init` run an install in project repo, by default. Can be disabled with --no-venv.

# Why?
Duh

# How did you test to ensure no regressions?
I saw it work in these cases:
- `banana install` -> install venv, downloads requirements.txt
- `banana init .` -> installs venv in current dir, downloads requirements.txt
- `banana init my-app` -> installs venv in my-app, downloads requirements.txt
