### PR TITLE
print the project name at the end

### DIFF
--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -26,6 +26,7 @@ def init(path, no_venv):
         install_venv(req_path, venv_path)
     click.echo('\n🍌 Project ready to go (hurrah!)')
     click.echo('\n🔥 To run a dev server with hot-reload, run:')
+    click.echo(f'cd {path[0]}')
     click.echo('banana dev')
 
 @click.command()

--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -13,7 +13,8 @@ def cli():
 @click.command()
 @click.argument('path', type=click.Path(exists=False, dir_okay=True, file_okay=False), nargs=-1)
 @click.option('--no-venv', is_flag=True, required=False, help="Disable automatic use of a virtual environment")
-def init(path, no_venv):
+@click.option('--no-install', is_flag=True, required=False, help="Disable automatic install of requirements.txt")
+def init(path, no_venv, no_install):
     click.echo('⏰ Downloading boilerplate...')
     target_dir = get_target_dir(path)
     download_boilerplate(target_dir)
@@ -23,10 +24,14 @@ def init(path, no_venv):
         create_venv(venv_path)
         click.echo('📦 Downloading packages...')
         req_path = os.path.join(target_dir, "requirements.txt")
-        install_venv(req_path, venv_path)
+
+        if not no_install:
+            install_venv(req_path, venv_path)
+
     click.echo('\n🍌 Project ready to go (hurrah!)')
     click.echo('\n🔥 To run a dev server with hot-reload, run:')
-    click.echo(f'cd {path[0]}')
+    if target_dir != ".":
+        click.echo(f'cd {target_dir}')
     click.echo('banana dev')
 
 @click.command()

--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -22,16 +22,18 @@ def init(path, no_venv, no_install):
         click.echo('🌎 Creating virtual environment...')
         venv_path = os.path.join(target_dir, "venv")
         create_venv(venv_path)
-        click.echo('📦 Downloading packages...')
-        req_path = os.path.join(target_dir, "requirements.txt")
 
         if not no_install:
+            click.echo('📦 Downloading packages...')
+            req_path = os.path.join(target_dir, "requirements.txt")
             install_venv(req_path, venv_path)
 
     click.echo('\n🍌 Project ready to go (hurrah!)')
     click.echo('\n🔥 To run a dev server with hot-reload, run:')
     if target_dir != ".":
         click.echo(f'cd {target_dir}')
+    if no_install:
+        click.echo(f'banana install')
     click.echo('banana dev')
 
 @click.command()


### PR DESCRIPTION
# What is this?
<img width="430" alt="Screenshot 2023-03-24 at 11 25 04" src="https://user-images.githubusercontent.com/24875419/227479983-0112e692-ba21-419a-b072-22aac9ba96ff.png">


# Why?
Small thing but many forget the exact name of the dir by the time all the packages load.

# How did you test to ensure no regressions?
Ran it myself

# If this is a new feature what is one way you can make this break?
If no path then this might throw