### PR TITLE
Feature/init warning

### DIFF
--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -17,6 +17,10 @@ def cli():
 def init(path, no_venv, no_install):
     click.echo('⏰ Downloading boilerplate...')
     target_dir = get_target_dir(path)
+    if target_dir == ".":
+        # verify they're not installing into an existing dir
+        if len(os.listdir(target_dir)) > 0:
+            click.confirm("This is not an empty directory, and the install may overwrite existing files.\nDo you want to proceed?", abort=True)
     download_boilerplate(target_dir)
     if not no_venv:
         click.echo('🌎 Creating virtual environment...')


### PR DESCRIPTION
# What is this?
Adds a confirmation prompt if user is about to potentially overwrite files in their dir with `banana init`

# Why?
So users don't shoot themselves in the foot

# How did you test to ensure no regressions?
Tested these cases:
- dir specified (usual behavior)
- in a dir with files:
    - no dir specified (prompt, aborts if I say N or ctrl_c)
    - `.` dir specified (prompt, aborts if I say N or ctrl_c)
- in a dir without files
    -  no dir specified (no prompt, just installs)
    -  `.` dir specified (no prompt, just installs)

# If this is a new feature what is one way you can make this break?
N/A