### PR TITLE
added autocompat

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ The handler() function is ran on every change to handler(), without needing to w
 4. Try changing the handler, see what happens!
 5. Try changing the init, see what happens!
 
+## Experimental features:
+- `banana dev --auto-compat=True` to make your GPU code compatible with a CPU machine, by ignoring to("cuda") calls
+
 ## Future Development:
-- Rewrite boilerplate and dev server to run [Potassium](https://github.com/bananaml/potassium) rather than the current demo code
 - Lock in a stable interface
 - Add the following commands
   - `banana build` -> verify production build

--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -51,11 +51,12 @@ def install(venv):
 
 @click.command()
 @click.option('--venv', default="venv", required=False, type=str, help="The path of the virtual environment to run in. Defaults to venv.")
+@click.option('--auto-compat', default=False, required=False, type=bool, help="Prevents cuda use if there is no GPU visible. Defaults to True.")
 @click.argument('entrypoint', type=click.Path(exists=True), nargs=-1)
-def dev(venv, entrypoint):
+def dev(venv, auto_compat, entrypoint):
     app_path = get_app_path(entrypoint)
     site_packages = get_site_packages(app_path, venv_name = venv)
-    run_dev_server(app_path, site_packages)
+    run_dev_server(app_path, site_packages, auto_compat)
 
 cli.add_command(init)
 cli.add_command(install)

--- a/banana_cli/cmd_dev.py
+++ b/banana_cli/cmd_dev.py
@@ -35,6 +35,7 @@ def split_file(watch):
     return init_block, handler_block
 
 replacements = {}
+# populate_replacements gathers all patterns seen for CUDA usage in pytorch and provides a replacement value for use in str.replace()
 def populate_replacements():
     replacements = {
         ".cuda()": "", 
@@ -65,7 +66,7 @@ def populate_replacements():
 
     return replacements
 
-
+# strip_cuda_calls replaces calls to cuda with calls to cpu
 def strip_cuda_calls(block: str):
     # from https://pytorch.org/docs/stable/notes/cuda.html
 

--- a/banana_cli/process/run.py
+++ b/banana_cli/process/run.py
@@ -1,3 +1,13 @@
 
 def run_cell(input_file):
     exec(input_file, globals())
+
+def check_for_gpu():
+    try:
+        exec('''
+import torch
+torch.tensor([1.,]).cuda()
+        ''', globals())
+        return True
+    except:
+        return False


### PR DESCRIPTION
# What is this?
Adds GPU autocompat for pytorch code

# Why?
So users can test GPU code locally and have it not crash

# How did you test to ensure no regressions?
It's an optional, default-off flag

# If this is a new feature what is one way you can make this break?
- Any CUDA use outside of app.py won't be addressed
- If the pattern is not addressed in the `populate_replacements()` logic, it will break
