### PR TITLE
refactor for breaking potassium change

### DIFF
--- a/banana_cli/process/cells.py
+++ b/banana_cli/process/cells.py
@@ -17,7 +17,7 @@ class ServerThread(threading.Thread):
         self.server.shutdown()
 '''
 
-run_init = "app.init_func()"
+run_init = "app._init_func()"
 
 start_server = '''
 flask_app = app._create_flask_app()


### PR DESCRIPTION
# What is this?
Updates banana-cli to call `app._init_func()` rather than `app.init_func()`

# Why?
due to renaming inbound from potassium branch `staging`

# How did you test to ensure no regressions?
will leave PR open then test once potassium branch is in

# If this is a new feature what is one way you can make this break?
N/A