### PR TITLE
Fix wrong init func reference

### DIFF
--- a/banana_cli/cmd_dev.py
+++ b/banana_cli/cmd_dev.py
@@ -95,7 +95,12 @@ def start_all(b1, b2, first_run = False):
     run_cell(b2)
     # run init
     print(colored("Running init()", 'yellow'))
-    run_cell(cells.run_init)
+    
+    try:
+        run_cell(cells.run_init)
+    except Exception as e:
+        run_cell("app.init_func()")
+
     # start server
     run_cell(cells.start_server)
     print(colored("Serving on http://localhost:8000\n------", 'green'))

--- a/banana_cli/process/cells.py
+++ b/banana_cli/process/cells.py
@@ -17,7 +17,7 @@ class ServerThread(threading.Thread):
         self.server.shutdown()
 '''
 
-run_init = "app.init_func()"
+run_init = "app._init_func()"
 
 start_server = '''
 flask_app = app._create_flask_app()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name='banana_cli',
     packages=['banana_cli', 'banana_cli.process'],
     py_modules=["cli"],
-    version='0.0.12',
+    version='0.0.13',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The Banana CLI helps you build Potassium apps',


### PR DESCRIPTION
# What is this?

The CLI was using the wrong function reference.

# Why?

<img width="855" alt="image" src="https://github.com/bananaml/banana-cli/assets/6206742/adb0a084-9bfd-44ab-81df-b3db6fe2b482">

# How did you test to ensure no regressions?

# If this is a new feature what is one way you can make this break?
