### PR TITLE
 added command for getting version

### DIFF
--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -1,10 +1,14 @@
 # click is our CLI library
 import click
+import json
 import os
 
 # local imports
 from .cmd_dev import run_dev_server
 from .utils import get_target_dir, get_app_path, get_site_packages, download_boilerplate, add_git, create_venv, install_venv
+
+info = open('info.json')
+data = json.loads(info.read())
 
 @click.group()
 def cli():
@@ -61,9 +65,15 @@ def dev(venv, auto_compat, entrypoint):
     site_packages = get_site_packages(app_path, venv_name = venv)
     run_dev_server(app_path, site_packages, auto_compat)
 
+@click.command()
+@click.option(help="Version of Banana Installed")
+def version(data):
+    click.echo(f" \n🍌 Banana version:{data['version']}")
+
 cli.add_command(init)
 cli.add_command(install)
 cli.add_command(dev)
+cli.add_command(version)
 
 if __name__ == "__main__":
     cli()

--- a/info.json
+++ b/info.json
@@ -1,0 +1,6 @@
+{
+    "name"  : "banana_cli",
+    "version" : "0.0.15",
+    "license" : "Apache License 2.0",
+    "description" : "The Banana CLI helps you build Potassium apps"
+}

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,21 @@
 from distutils.core import setup
+import json
 import setuptools
 from pathlib import Path
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+info = open('info.json')
+data = json.loads(info.read())
 
 setup(
-    name='banana_cli',
+    name=data['name'],
     packages=['banana_cli', 'banana_cli.process'],
     py_modules=["cli"],
-    version='0.0.15',
-    license='Apache License 2.0',
+    version=data['version'],
+    license=data['license'],
     # Give a short description about your library
-    description='The Banana CLI helps you build Potassium apps',
+    description=data['description'],
     long_description=long_description,
     long_description_content_type='text/markdown',
     author='Erik Dunteman',


### PR DESCRIPTION

# What is this?
Added command for getting banana version

# Why?
No command exists for getting banana version
A solution to issue: https://github.com/bananaml/banana-cli/issues/5

# How did you test to ensure no regressions?
N/A

# If this is a new feature what is one way you can make this break?
By deleting the info.json file

The info.json file can be used to modify name, version, description, etc. 