### PR TITLE
Archive first, then get upload url.

### DIFF
--- a/banana_cli/cli.py
+++ b/banana_cli/cli.py
@@ -318,14 +318,6 @@ def deploy():
         # todo: the model exists and re-deploying case
 
         sp.text = 'Deploying project...'
-        
-        upload_response = upload_project(api_key, config.get("projectId"))
-        if upload_response is None:
-            with sp.hidden():
-                print(HTML(u'❌   <err-msg>Error getting upload URL for project</err-msg>'), style=style)
-                exit(1)
-        upload_url = upload_response.get("uploadUrl")
-        upload_key = upload_response.get("key")
 
         import tarfile
         from gitignore_parser import parse_gitignore
@@ -352,6 +344,14 @@ def deploy():
             print(HTML(u'✅   <yay-msg>Archived</yay-msg>'), style=style)
 
         sp.text = 'Uploading...'
+
+        upload_response = upload_project(api_key, config.get("projectId"))
+        if upload_response is None:
+            with sp.hidden():
+                print(HTML(u'❌   <err-msg>Error getting upload URL for project</err-msg>'), style=style)
+                exit(1)
+        upload_url = upload_response.get("uploadUrl")
+        upload_key = upload_response.get("key")
 
         def upload_to_presigned_url(presigned_url, file_path):
             with open(file_path, 'rb') as f:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['banana_cli', 'banana_cli.process'],
     py_modules=["cli"],
     python_requires='>=3.7',
-    version='0.1.1',
+    version='0.1.2',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The Banana CLI helps you build Potassium apps',


### PR DESCRIPTION
# What is this?

Switch the order in which archiving and upload url generation is done.

# Why?

Large payloads take a while to archive, and might stretch beyond the expiration window offered by the presigned url.

# How did you test it works without  regressions?

Ran locally against prod.
